### PR TITLE
fix variable names for retrieving children of directories

### DIFF
--- a/server/externalAPI/dropbox/dropbox-api-v1.js
+++ b/server/externalAPI/dropbox/dropbox-api-v1.js
@@ -95,8 +95,8 @@ dropboxAPI.getFileDirectories = function getFileDirectories(path, depth, accessT
             };
 
             //send a directory request
-            if((all || depth > 0) && fileObject.type === 'folder') {
-              directoryRequest(fileObject.path, fileObject.children, depth - 1);
+            if((all || depth > 0) && fileObject.fileType === 'folder') {
+              directoryRequest(fileObject.filePath, fileObject.children, depth - 1);
             }
 
             directory.push(fileObject);


### PR DESCRIPTION
I had the wrong variable names specified, which led to the recursion being false.
